### PR TITLE
add mixed separator #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Attributes where sub keys are other than full numbers are converted into Python 
 	data = {
 		'the.0.chained.key.0.are.awesome.0.0': 'im here !!'
 	}
+	# with "mixed" separator option:
+	data = {
+		'the[0].chained.key[0].are.awesome[0][0]': 'im here !!'
+	}
 ```
 
 
@@ -149,6 +153,8 @@ For this to work perfectly, you must follow the following rules:
 - A first key always need to be set. ex: `title[0]` or `title`. In both cases the first key is `title`
 
 - Each sub key need to be separate by brackets `[ ]` or dot `.` (depends of your options)
+
+- For `mixed` options, brackets `[]` is for list, and dot `.` is for object
 
 - Don't put spaces between separators.
 
@@ -163,7 +169,7 @@ For this to work perfectly, you must follow the following rules:
 	# Separators:
 	# with bracket:  article[title][authors][0]: "jhon doe"
 	# with dot:      article.title.authors.0: "jhon doe"
-	'separator': 'bracket' or 'dot', # default is bracket
+	'separator': 'bracket' or 'dot' or 'mixed', # default is bracket
 
 
 	# raise a expections when you have duplicate keys

--- a/tests/test_mixed_separator.py
+++ b/tests/test_mixed_separator.py
@@ -1,0 +1,285 @@
+from nested_multipart_parser import NestedParser
+from unittest import TestCase
+
+
+class TestSettingsSeparatorMixed(TestCase):
+
+    def test_assign_duplicate_list(self):
+        data = {
+            "title": 42,
+            "title[0]": 101
+        }
+        p = NestedParser(
+            data, {"raise_duplicate": False, "assign_duplicate": True, "separator": "mixed", "separator": "mixed"})
+        self.assertTrue(p.is_valid())
+        expected = {
+            "title": [101]
+        }
+        self.assertEqual(p.validate_data, expected)
+
+    def test_assign_duplicate_number_after_list(self):
+        data = {
+            "title[0]": 101,
+            "title": 42,
+        }
+        p = NestedParser(
+            data, {"raise_duplicate": False, "assign_duplicate": True, "separator": "mixed", "separator": "mixed"})
+        self.assertTrue(p.is_valid())
+        expected = {
+            "title": 42
+        }
+        self.assertEqual(p.validate_data, expected)
+
+    def test_assign_nested_duplicate_number_after_list(self):
+        data = {
+            "title[0].sub[0]": 101,
+            "title[0].sub": 42,
+        }
+        p = NestedParser(
+            data, {"raise_duplicate": False, "assign_duplicate": True, "separator": "mixed"})
+        self.assertTrue(p.is_valid())
+        expected = {
+            "title": [
+                {
+                    "sub": 42
+                }
+            ]
+        }
+        self.assertEqual(p.validate_data, expected)
+
+    def test_assign_nested_duplicate_number_after_list2(self):
+        data = {
+            "title[0].sub": 42,
+            "title[0].sub[0]": 101,
+        }
+        p = NestedParser(
+            data, {"raise_duplicate": False, "assign_duplicate": True, "separator": "mixed"})
+        self.assertTrue(p.is_valid())
+        expected = {
+            "title": [
+                {
+                    "sub": [101]
+                }
+            ]
+        }
+        self.assertEqual(p.validate_data, expected)
+
+    def test_assign_nested_duplicate_number_after_dict(self):
+        data = {
+            "title[0].sub": 42,
+            "title[0].sub.title": 101,
+        }
+        p = NestedParser(
+            data, {"raise_duplicate": False, "assign_duplicate": True, "separator": "mixed"})
+        self.assertTrue(p.is_valid())
+        expected = {
+            "title": [
+                {
+                    "sub": {
+                        "title": 101
+                    }
+                }
+            ]
+        }
+        self.assertEqual(p.validate_data, expected)
+
+    def test_assign_nested_duplicate_number_after_dict2(self):
+        data = {
+            "title[0].sub.title": 101,
+            "title[0].sub": 42,
+        }
+        p = NestedParser(
+            data, {"raise_duplicate": False, "assign_duplicate": True, "separator": "mixed"})
+        self.assertTrue(p.is_valid())
+        expected = {
+            "title": [
+                {
+                    "sub": 42
+                }
+            ]
+        }
+        self.assertEqual(p.validate_data, expected)
+
+    def test_mixed_spearator(self):
+        data = {
+            'title': 'lalal',
+            'article.object': 'lalal',
+        }
+        parser = NestedParser(data, {"separator": "mixed"})
+        self.assertTrue(parser.is_valid())
+        expected = {
+            "title": 'lalal',
+            "article": {
+                "object": "lalal"
+            }
+        }
+        self.assertEqual(expected, parser.validate_data)
+
+    def test_mixed_int_object(self):
+        data = {
+            'title': 'lalal',
+            'article.0': 'lalal',
+        }
+        parser = NestedParser(data, {"separator": "mixed"})
+        self.assertTrue(parser.is_valid())
+        expected = {
+            "title": 'lalal',
+            "article": {
+                "0": "lalal"
+            }
+        }
+        self.assertEqual(expected, parser.validate_data)
+
+    def test_mixed_int_list(self):
+        data = {
+            'title': 'lalal',
+            'article[0]': 'lalal',
+        }
+        parser = NestedParser(data, {"separator": "mixed"})
+        self.assertTrue(parser.is_valid())
+        expected = {
+            "title": 'lalal',
+            "article": [
+                "lalal"
+            ]
+        }
+        self.assertEqual(expected, parser.validate_data)
+
+    def test_real(self):
+        data = {
+            'title': 'title',
+            'date': "time",
+            'langs[0].id': "id",
+            'langs[0].title': 'title',
+            'langs[0].description': 'description',
+            'langs[0].language': "language",
+            'langs[1].id': "id1",
+            'langs[1].title': 'title1',
+            'langs[1].description': 'description1',
+            'langs[1].language': "language1"
+        }
+        parser = NestedParser(data, {"separator": "mixed"})
+        self.assertTrue(parser.is_valid())
+        expected = {
+            'title': 'title',
+            'date': "time",
+            'langs': [
+                {
+                    'id': 'id',
+                    'title': 'title',
+                    'description': 'description',
+                    'language': 'language'
+                },
+                {
+                    'id': 'id1',
+                    'title': 'title1',
+                    'description': 'description1',
+                    'language': 'language1'
+                }
+            ]
+        }
+        self.assertDictEqual(parser.validate_data, expected)
+
+    def test_mixed_invalid_list_index(self):
+        data = {
+            'title': 'lalal',
+            'article[0f]': 'lalal',
+        }
+        parser = NestedParser(data, {"separator": "mixed"})
+        self.assertFalse(parser.is_valid())
+
+    def test_mixed_invalid_list_empty_index(self):
+        data = {
+            'title': 'lalal',
+            'article[]': 'lalal',
+        }
+        parser = NestedParser(data, {"separator": "mixed"})
+        self.assertFalse(parser.is_valid())
+
+    def test_mixed_invalid_bracket(self):
+        data = {
+            'title': 'lalal',
+            'article[': 'lalal',
+        }
+        parser = NestedParser(data, {"separator": "mixed"})
+        self.assertFalse(parser.is_valid())
+
+    def test_mixed_invalid_bracket2(self):
+        data = {
+            'title': 'lalal',
+            'article]': 'lalal',
+        }
+        parser = NestedParser(data, {"separator": "mixed"})
+        self.assertFalse(parser.is_valid())
+
+    def test_mixed_invalid_list_dot(self):
+        data = {
+            'title': 'lalal',
+            'article[3.]': 'lalal',
+        }
+        parser = NestedParser(data, {"separator": "mixed"})
+        self.assertFalse(parser.is_valid())
+
+    def test_mixed_invalid_list_negative_index(self):
+        data = {
+            'title': 'lalal',
+            'article[-3]': 'lalal',
+        }
+        parser = NestedParser(data, {"separator": "mixed"})
+        self.assertFalse(parser.is_valid())
+
+    def test_mixed_invalid_object(self):
+        data = {
+            'title': 'lalal',
+            'article..op': 'lalal',
+        }
+        parser = NestedParser(data, {"separator": "mixed"})
+        self.assertFalse(parser.is_valid())
+
+    def test_mixed_invalid_object2(self):
+        data = {
+            'title': 'lalal',
+            'article.op.': 'lalal',
+        }
+        parser = NestedParser(data, {"separator": "mixed"})
+        self.assertFalse(parser.is_valid())
+
+    def test_mixed_invalid_object3(self):
+        data = {
+            'title': 'lalal',
+            'article.op..': 'lalal',
+        }
+        parser = NestedParser(data, {"separator": "mixed"})
+        self.assertFalse(parser.is_valid())
+
+    def test_mixed_invalid_object4(self):
+        data = {
+            'title': 'lalal',
+            'article[0]op': 'lalal',
+        }
+        parser = NestedParser(data, {"separator": "mixed"})
+        self.assertFalse(parser.is_valid())
+
+    def test_mixed_invalid_list_with_object_dot(self):
+        data = {
+            'title': 'lalal',
+            'article[0].op..': 'lalal',
+        }
+        parser = NestedParser(data, {"separator": "mixed"})
+        self.assertFalse(parser.is_valid())
+
+    def test_mixed_invalid_list_with_object_dot2(self):
+        data = {
+            'title': 'lalal',
+            'article[0]op[0]e.': 'lalal',
+        }
+        parser = NestedParser(data, {"separator": "mixed"})
+        self.assertFalse(parser.is_valid())
+
+    def test_mixed_invalid_list_with_object_dot3(self):
+        data = {
+            'title': 'lalal',
+            'article.op.[0]': 'lalal',
+        }
+        parser = NestedParser(data, {"separator": "mixed"})
+        self.assertFalse(parser.is_valid())

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -100,22 +100,6 @@ class TestParser(TestCase):
         }
         self.assertEqual(expected, parser.validate_data)
 
-    def test_parser_object_reasing(self):
-        data = {
-            'title[id][length]': 'lalal',
-            'title[id][  length  ]': 'lalal',
-        }
-        parser = NestedParser(data)
-        self.assertTrue(parser.is_valid())
-        expected = {
-            'title': {
-                'id': {
-                    'length': 'lalal'
-                }
-            }
-        }
-        self.assertEqual(expected, parser.validate_data)
-
     def test_parser_object_reasing2(self):
         data = {
             'title[id][length]': 'lalal',
@@ -170,16 +154,6 @@ class TestParser(TestCase):
         parser = NestedParser(data)
         self.assertFalse(parser.is_valid())
 
-    def test_parser_classic_double_assign(self):
-        data = {
-            'title   ': 'lalal',
-            'title': 'dddddddddddddd'
-        }
-        parser = NestedParser(data)
-        self.assertTrue(parser.is_valid())
-        expected = {'title': 'lalal'}
-        self.assertEqual(expected, parser.validate_data)
-
     def test_parser_list(self):
         data = {
             'title': 'lalal',
@@ -225,24 +199,6 @@ class TestParser(TestCase):
             }
         }
         self.assertTrue(parser.is_valid())
-        self.assertEqual(expected, parser.validate_data)
-
-    def test_parser_list_double_assign(self):
-        data = {
-            'title': 'lalal',
-            'list[0]': 'icicici',
-            'list[0 ]': 'new',
-            'list[1]': 'neeew',
-        }
-        parser = NestedParser(data)
-        self.assertTrue(parser.is_valid())
-        expected = {
-            'title': 'lalal',
-            'list': [
-                'icicici',
-                'neeew'
-            ]
-        }
         self.assertEqual(expected, parser.validate_data)
 
     def test_real(self):

--- a/tests/test_parser_assign.py
+++ b/tests/test_parser_assign.py
@@ -4,31 +4,6 @@ from unittest import TestCase
 
 class TestSettingsSeparator(TestCase):
 
-    def test_raise_duplicate(self):
-        data = {
-            "title": 42,
-            "title  ": 101
-        }
-        p = NestedParser(data, {"raise_duplicate": False})
-        self.assertTrue(p.is_valid())
-        expected = {
-            "title": 42
-        }
-        self.assertEqual(p.validate_data, expected)
-
-    def test_assign_duplicate(self):
-        data = {
-            "title": 42,
-            "title  ": 101
-        }
-        p = NestedParser(
-            data, {"raise_duplicate": False, "assign_duplicate": True})
-        self.assertTrue(p.is_valid())
-        expected = {
-            "title": 101
-        }
-        self.assertEqual(p.validate_data, expected)
-
     def test_assign_duplicate_list(self):
         data = {
             "title": 42,

--- a/tests/test_parser_separator.py
+++ b/tests/test_parser_separator.py
@@ -84,22 +84,6 @@ class TestSettingsSeparator(TestCase):
         }
         self.assertEqual(expected, parser.validate_data)
 
-    def test_parser_object_reasing(self):
-        data = {
-            'title.id.length': 'lalal',
-            'title.id.  length  ': 'lalal',
-        }
-        parser = NestedParser(data, {"separator": "dot"})
-        self.assertTrue(parser.is_valid())
-        expected = {
-            'title': {
-                'id': {
-                    'length': 'lalal'
-                }
-            }
-        }
-        self.assertEqual(expected, parser.validate_data)
-
     def test_parser_object_reasing2(self):
         data = {
             'title.id.length': 'lalal',
@@ -154,16 +138,6 @@ class TestSettingsSeparator(TestCase):
         parser = NestedParser(data, {"separator": "dot"})
         self.assertFalse(parser.is_valid())
 
-    def test_parser_classic_double_assign(self):
-        data = {
-            'title   ': 'lalal',
-            'title': 'dddddddddddddd'
-        }
-        parser = NestedParser(data, {"separator": "dot"})
-        self.assertTrue(parser.is_valid())
-        expected = {'title': 'lalal'}
-        self.assertEqual(expected, parser.validate_data)
-
     def test_parser_list(self):
         data = {
             'title': 'lalal',
@@ -211,23 +185,12 @@ class TestSettingsSeparator(TestCase):
         self.assertTrue(parser.is_valid())
         self.assertEqual(expected, parser.validate_data)
 
-    def test_parser_list_double_assign(self):
+    def test_parser_space_key(self):
         data = {
-            'title': 'lalal',
-            'list.0': 'icicici',
-            'list.0 ': 'new',
-            'list.1': 'neeew',
+            'title ': 'lalal',
         }
         parser = NestedParser(data, {"separator": "dot"})
-        self.assertTrue(parser.is_valid())
-        expected = {
-            'title': 'lalal',
-            'list': [
-                'icicici',
-                'neeew'
-            ]
-        }
-        self.assertEqual(expected, parser.validate_data)
+        self.assertFalse(parser.is_valid())
 
     def test_real(self):
         data = {


### PR DESCRIPTION
added separator "mixed",
- key with bracket `[]` is for list
- key with dot `.` is for object